### PR TITLE
Ampliación de soporte de idiomas y mejora visual del selector

### DIFF
--- a/website/messages/it.json
+++ b/website/messages/it.json
@@ -1,0 +1,47 @@
+{
+  "Navbar": {
+    "features": "Funzionalità",
+    "download": "Scarica"
+  },
+  "HeroSection": {
+    "title": "Il tuo ricettario digitale",
+    "description": "Conserva, organizza e trova facilmente tutte le tue ricette preferite in un unico posto. Ora disponibile per Android!",
+    "download": "Scarica ora"
+  },
+  "FeaturesSection": {
+    "title": "Caratteristiche principali",
+    "feature1_title": "Funziona offline",
+    "feature1_description": "Informazioni memorizzate sul tuo dispositivo, non è necessaria alcuna connessione Internet.",
+    "feature2_title": "Gestisci le tue ricette",
+    "feature2_description": "Visualizza, aggiungi ed elimina ricette con istruzioni e ingredienti sempre a portata di mano.",
+    "feature3_title": "Modalità scura",
+    "feature3_description": "Tema scuro ideale per cucinare in ambienti con scarsa illuminazione.",
+    "feature4_title": "Prossimamente: Condividi",
+    "feature4_description": "Presto potrai condividere le tue creazioni culinarie con amici e familiari.",
+    "feature5_title": "Prossimamente: AI per le ricette",
+    "feature5_description": "Generazione automatica di ricette da immagini tramite AI."
+  },
+  "CTASection": {
+    "title": "Disponibile ora!",
+    "description": "L'app The Recipes è ora disponibile per Android. Scarica l'app e inizia a organizzare le tue ricette preferite oggi stesso.",
+    "download_now": "Scarica ora",
+    "view_github": "Visualizza su GitHub",
+    "discover_features": "Scopri le funzionalità"
+  },
+  "Footer": {
+    "tagline": "Il tuo assistente culinario digitale",
+    "section_recipes": "The Recipes",
+    "link_features": "Funzionalità",
+    "link_development": "Sviluppo",
+    "section_contact": "Contatto",
+    "section_preferences": "Preferenze",
+    "theme_label": "Tema corrente:",
+    "theme_light": "Modalità chiara",
+    "theme_dark": "Modalità scura",
+    "theme_system": "Modalità di sistema",
+    "theme_toggle_to_dark": "Passa alla modalità scura",
+    "theme_toggle_to_system": "Passa alla modalità di sistema",
+    "theme_toggle_to_light": "Passa alla modalità chiara",
+    "copyright": "© {year} The Recipes App. Tutti i diritti riservati."
+  }
+}

--- a/website/messages/ja.json
+++ b/website/messages/ja.json
@@ -1,0 +1,47 @@
+{
+  "Navbar": {
+    "features": "特徴",
+    "download": "ダウンロード"
+  },
+  "HeroSection": {
+    "title": "あなたのデジタルレシピブック",
+    "description": "お気に入りのレシピをすべて1か所に保存、整理し、簡単に見つけられます。Androidで利用可能になりました！",
+    "download": "今すぐダウンロード"
+  },
+  "FeaturesSection": {
+    "title": "主な特徴",
+    "feature1_title": "オフラインで動作",
+    "feature1_description": "情報はデバイスに保存され、インターネットは不要です。",
+    "feature2_title": "レシピを管理",
+    "feature2_description": "手順と材料を常に手元に置いて、レシピを表示、追加、削除できます。",
+    "feature3_title": "ダークモード",
+    "feature3_description": "暗い環境での料理に最適なダークテーマ。",
+    "feature4_title": "近日公開：共有",
+    "feature4_description": "まもなく、あなたの料理作品を友人や家族と共有できるようになります。",
+    "feature5_title": "近日公開：レシピ用AI",
+    "feature5_description": "AIを使用して画像からレシピを自動生成します。"
+  },
+  "CTASection": {
+    "title": "今すぐ利用可能！",
+    "description": "The Recipes AppがAndroidで利用可能になりました。アプリをダウンロードして、今日からお気に入りのレシピの整理を始めましょう。",
+    "download_now": "今すぐダウンロード",
+    "view_github": "GitHubで表示",
+    "discover_features": "特徴を発見"
+  },
+  "Footer": {
+    "tagline": "あなたのデジタル料理アシスタント",
+    "section_recipes": "The Recipes",
+    "link_features": "特徴",
+    "link_development": "開発",
+    "section_contact": "連絡先",
+    "section_preferences": "設定",
+    "theme_label": "現在のテーマ：",
+    "theme_light": "ライトモード",
+    "theme_dark": "ダークモード",
+    "theme_system": "システムモード",
+    "theme_toggle_to_dark": "ダークモードに切り替え",
+    "theme_toggle_to_system": "システムモードに切り替え",
+    "theme_toggle_to_light": "ライトモードに切り替え",
+    "copyright": "© {year} The Recipes App. 無断複写・転載を禁じます。"
+  }
+}

--- a/website/messages/ko.json
+++ b/website/messages/ko.json
@@ -1,0 +1,47 @@
+{
+  "Navbar": {
+    "features": "기능",
+    "download": "다운로드"
+  },
+  "HeroSection": {
+    "title": "나만의 디지털 레시피 북",
+    "description": "좋아하는 모든 레시피를 한 곳에 저장, 정리하고 쉽게 찾아보세요. 이제 Android에서 사용할 수 있습니다!",
+    "download": "지금 다운로드"
+  },
+  "FeaturesSection": {
+    "title": "주요 기능",
+    "feature1_title": "오프라인 작동",
+    "feature1_description": "정보는 기기에 저장되며 인터넷 연결이 필요하지 않습니다.",
+    "feature2_title": "레시피 관리",
+    "feature2_description": "지침과 재료를 항상 손쉽게 확인하며 레시피를 보고, 추가하고, 삭제할 수 있습니다.",
+    "feature3_title": "다크 모드",
+    "feature3_description": "어두운 환경에서 요리하기에 이상적인 다크 테마입니다.",
+    "feature4_title": "출시 예정: 공유",
+    "feature4_description": "곧 친구 및 가족과 요리 창작물을 공유할 수 있게 됩니다.",
+    "feature5_title": "출시 예정: 레시피용 AI",
+    "feature5_description": "AI를 사용하여 이미지에서 레시피를 자동으로 생성합니다."
+  },
+  "CTASection": {
+    "title": "지금 이용 가능!",
+    "description": "The Recipes 앱이 이제 Android에서 사용 가능합니다. 앱을 다운로드하고 오늘부터 좋아하는 레시피 정리를 시작하세요.",
+    "download_now": "지금 다운로드",
+    "view_github": "GitHub에서 보기",
+    "discover_features": "기능 살펴보기"
+  },
+  "Footer": {
+    "tagline": "나만의 디지털 요리 도우미",
+    "section_recipes": "The Recipes",
+    "link_features": "기능",
+    "link_development": "개발",
+    "section_contact": "연락처",
+    "section_preferences": "환경 설정",
+    "theme_label": "현재 테마:",
+    "theme_light": "라이트 모드",
+    "theme_dark": "다크 모드",
+    "theme_system": "시스템 모드",
+    "theme_toggle_to_dark": "다크 모드로 전환",
+    "theme_toggle_to_system": "시스템 모드로 전환",
+    "theme_toggle_to_light": "라이트 모드로 전환",
+    "copyright": "© {year} The Recipes App. 모든 권리 보유."
+  }
+}

--- a/website/next.config.js
+++ b/website/next.config.js
@@ -9,6 +9,11 @@ const nextConfig = {
         hostname: 'firebasestorage.googleapis.com',
         pathname: '/v0/b/the-recipes-90baa.appspot.com/o/recipe-images**',
       },
+      {
+        protocol: 'https',
+        hostname: 'flag.vercel.app',
+        pathname: '/s/**',
+      },
     ],
   },
 };

--- a/website/src/components/LanguageSelect.tsx
+++ b/website/src/components/LanguageSelect.tsx
@@ -3,14 +3,15 @@
 import { useState, useEffect, useRef } from "react";
 import { useLocale } from "next-intl";
 import { setCookie } from "cookies-next";
+import Image from "next/image";
 
 const languageOptions = [
-  { code: "es", name: "Español" },
-  { code: "en", name: "English" },
-  { code: "de", name: "Deutsch" },
-  { code: "fr", name: "Français" },
-  { code: "pt", name: "Português" },
-  { code: "zh", name: "中文" },
+  { code: "es", name: "Español", flagCode: "ES" },
+  { code: "en", name: "English", flagCode: "GB" },
+  { code: "de", name: "Deutsch", flagCode: "DE" },
+  { code: "fr", name: "Français", flagCode: "FR" },
+  { code: "pt", name: "Português", flagCode: "PT" },
+  { code: "zh", name: "中文", flagCode: "CN" },
 ];
 
 export default function LanguageSelect() {
@@ -54,6 +55,13 @@ export default function LanguageSelect() {
     return language ? language.name : "English";
   };
 
+  const getCurrentLanguageFlag = () => {
+    const language = languageOptions.find(
+      (lang) => lang.code === selectedLanguage
+    );
+    return language ? language.flagCode : "GB";
+  };
+
   return (
     <div className="relative" ref={dropdownRef}>
       <button
@@ -62,6 +70,14 @@ export default function LanguageSelect() {
         aria-label="Seleccionar idioma"
         aria-expanded={isOpen}
       >
+        <Image
+          src={`https://flag.vercel.app/s/${getCurrentLanguageFlag()}.svg`}
+          alt={getCurrentLanguageName()}
+          width={16}
+          height={16}
+          className="inline-block ml-2"
+          loading="lazy"
+        />
         <span className="text-sm font-medium text-orange-700 dark:text-orange-400">
           {getCurrentLanguageName()}
         </span>
@@ -90,13 +106,21 @@ export default function LanguageSelect() {
               <li key={language.code}>
                 <button
                   onClick={() => changeLanguage(language.code)}
-                  className={`block w-full text-left px-4 py-2 text-sm ${
+                  className={`flex justify-start items-center w-full gap-0 text-left px-4 py-2 text-sm ${
                     language.code === selectedLanguage
                       ? "bg-orange-100 dark:bg-orange-900/40 text-orange-600 dark:text-orange-400 font-medium"
                       : "text-zinc-700 dark:text-zinc-300 hover:bg-orange-50 dark:hover:bg-orange-900/20 hover:text-orange-600 dark:hover:text-orange-400"
                   }`}
                 >
-                  {language.name}
+                  <Image
+                    src={`https://flag.vercel.app/s/${language.flagCode}.svg`}
+                    alt={language.name}
+                    width={16}
+                    height={16}
+                    className="inline-block mr-2"
+                    loading="lazy"
+                  />
+                  <span>{language.name}</span>
                 </button>
               </li>
             ))}

--- a/website/src/components/LanguageSelect.tsx
+++ b/website/src/components/LanguageSelect.tsx
@@ -9,9 +9,12 @@ const languageOptions = [
   { code: "es", name: "Español", flagCode: "ES" },
   { code: "en", name: "English", flagCode: "GB" },
   { code: "de", name: "Deutsch", flagCode: "DE" },
+  { code: "it", name: "Italiano", flagCode: "IT" },
   { code: "fr", name: "Français", flagCode: "FR" },
   { code: "pt", name: "Português", flagCode: "PT" },
   { code: "zh", name: "中文", flagCode: "CN" },
+  { code: "ja", name: "日本語", flagCode: "JP" },
+  { code: "ko", name: "한국어", flagCode: "KR" },
 ];
 
 export default function LanguageSelect() {

--- a/website/src/i18n/request.ts
+++ b/website/src/i18n/request.ts
@@ -3,7 +3,7 @@ import { cookies, headers } from "next/headers";
 import { match } from "@formatjs/intl-localematcher";
 import Negotiator from "negotiator";
 
-const supportedLocales = ["en", "es", "de", "fr", "pt", "zh"];
+const supportedLocales = ["en", "es", "de", "it", "fr", "pt", "zh", "ja", "ko"];
 const defaultLocale = "en";
 
 async function getBrowserLocale(): Promise<string | null> {


### PR DESCRIPTION
Este pull request continúa la expansión de la internacionalización de la aplicación, añadiendo soporte para nuevos idiomas y mejorando la experiencia del usuario al seleccionar el idioma:

* **Soporte para italiano, japonés y coreano:** Se ha añadido soporte para tres nuevos idiomas: italiano, japonés y coreano, incluyendo los archivos de traducción necesarios.
* **Añadir banderas al selector de idioma:** Se han añadido banderas representativas junto a cada opción de idioma en el selector, facilitando la identificación visual y mejorando la usabilidad.